### PR TITLE
Add MANIFEST.in to include LICENSE and README files.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README


### PR DESCRIPTION
`pip install lesscpy` from pypi fails without these includes since they're referenced from `setup.py`
