### PR TITLE
Fixup use of argparse for python3.3

### DIFF
--- a/lesscpy/scripts/compiler.py
+++ b/lesscpy/scripts/compiler.py
@@ -84,8 +84,9 @@ def run():
     """Run compiler
     """
     aparse = argparse.ArgumentParser(description='LessCss Compiler',
-                                     epilog='<< jtm@robot.is @_o >>',
-                                     version=VERSION_STR)
+                                     epilog='<< jtm@robot.is @_o >>')
+    aparse.add_argument('-v', '--version', action='version',
+                        version=VERSION_STR)
     aparse.add_argument('-I', '--include', action="store", type=str,
                         help="Included less-files (comma separated)")
     aparse.add_argument('-V', '--verbose', action="store_true",


### PR DESCRIPTION
The version keyword is no longer supported in argparse in python3.3.

Switch to using '--version' option instead.
