### PR TITLE
[fix #48] compiler: missing default for indent, missing `spaces` option

### DIFF
--- a/lesscpy/__init__.py
+++ b/lesscpy/__init__.py
@@ -1,7 +1,8 @@
 __version_info__ = ('0', '10', '1')
 __version__ = '.'.join(__version_info__)
 
-def compile(file, minify=False, xminify=False, tabs=False):
+
+def compile(file, minify=False, xminify=False, tabs=False, spaces=True):
     from .lessc import parser
     from .lessc import formatter
 
@@ -10,6 +11,7 @@ def compile(file, minify=False, xminify=False, tabs=False):
             self.minify = minify
             self.xminify = xminify
             self.tabs = tabs
+            self.spaces = spaces
 
     p = parser.LessParser(fail_with_exc=True)
     opt = Opt()


### PR DESCRIPTION
Fix issue with missing default for indentation options and add option for `spaces`.
