### PR TITLE
 Syntax Error, token: `css_filter`, `and (@b = @a)`

### DIFF
--- a/lesscpy/lessc/lexer.py
+++ b/lesscpy/lessc/lexer.py
@@ -108,7 +108,7 @@ class LessLexer:
     def t_css_filter(self, t):
         (r'\[[^\]]*\]'
          '|(not|lang|nth-[a-z\-]+)\(.+\)'
-         '|and[ \t]\([^><\{]+\)')
+         '|and[ \t]\([^><=\{]+\)')
         return t
 
     def t_css_ms_filter(self, t):

--- a/lesscpy/lessc/parser.py
+++ b/lesscpy/lessc/parser.py
@@ -23,7 +23,7 @@ from . import utility
 from .scope import Scope
 from .color import Color
 from lesscpy.exceptions import CompilationError
-from lesscpy.plib import Block, Call, Deferred, Expression, Identifier, Mixin, Property, Statement, Variable
+from lesscpy.plib import Block, Call, Deferred, Expression, Identifier, Mixin, Property, Statement, Variable, Import
 
 class ErrorRegister(object):
     """
@@ -224,15 +224,20 @@ class LessParser(object):
         p[0].parse(None)
 
     def p_statement_import(self, p):
-        """ import_statement     : css_import t_ws css_string t_semicolon
+        """ import_statement     : css_import t_ws string t_semicolon
+                                 | css_import t_ws css_string t_semicolon
                                  | css_import t_ws css_string media_query_list t_semicolon
                                  | css_import t_ws fcall t_semicolon
                                  | css_import t_ws fcall media_query_list t_semicolon
         """
+        #import pdb; pdb.set_trace()
         if self.importlvl > 8:
             raise ImportError(
                 'Recrusive import level too deep > 8 (circular import ?)')
         if isinstance(p[3], str):
+            ipath = utility.destring(p[3])
+        elif isinstance(p[3], list):
+            p[3] = Import(p[3], p.lineno(4)).parse(self.scope)
             ipath = utility.destring(p[3])
         elif isinstance(p[3], Call):
             # NOTE(saschpe): Always in the form of 'url("...");', so parse it

--- a/lesscpy/plib/__init__.py
+++ b/lesscpy/plib/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     'Property',
     'Statement',
     'Variable'
+    'Import',
 ]
 from .block import Block
 from .call import Call
@@ -29,3 +30,4 @@ from .node import Node
 from .property import Property
 from .statement import Statement
 from .variable import Variable
+from .import_ import Import

--- a/lesscpy/plib/import_.py
+++ b/lesscpy/plib/import_.py
@@ -1,0 +1,39 @@
+# -*- coding: utf8 -*-
+"""
+.. module:: lesscpy.plib.property
+    :synopsis: Import node.
+
+    Copyright (c)
+    See LICENSE for details.
+.. moduleauthor:: Johann T. Mariusson <jtm@robot.is>
+"""
+from .node import Node
+
+
+class Import(Node):
+
+    """Represents CSS property declaration.
+    """
+
+    def parse(self, scope):
+        """Parse node
+        args:
+            scope (Scope): current scope
+        raises:
+            SyntaxError
+        returns:
+            parsed
+        """
+        if not self.parsed:
+            self.parsed = ''.join(self.process(self.tokens, scope))
+        return self.parsed
+
+    def fmt(self, fills):
+        return ''
+
+    def copy(self):
+        """ Return a full copy of self
+        Returns:
+            Import object
+        """
+        return Import([t for t in self.tokens], 0)

--- a/test/css/imports.css
+++ b/test/css/imports.css
@@ -2,6 +2,9 @@
 @import 'some/other.css.file.CSS';
 @import 'some.css' all;
 @import "some.print.css" print;
+.foo {
+	color: blue;
+}
 .mixin {
 	color: red;
 }

--- a/test/css/imports.min.css
+++ b/test/css/imports.min.css
@@ -2,6 +2,7 @@
 @import 'some/other.css.file.CSS';
 @import 'some.css' all;
 @import "some.print.css" print;
+.foo{color:blue;}
 .mixin{color:red;}
 .mixin{color:red;}
 .import{color:red;width:6px;height:9px;}

--- a/test/less/imports.less
+++ b/test/less/imports.less
@@ -11,6 +11,8 @@
 /*
 	Less imports
 */
+@foo: "foo";
+@import './imports/@{foo}.less';
 @import './imports/import.less';
 @import './imports/import.less'; // redundant
 @import './imports/import_f'; // No ext

--- a/test/less/imports/foo.less
+++ b/test/less/imports/foo.less
@@ -1,0 +1,1 @@
+.foo { color: blue; }

--- a/test/less/mixin-args-guards.less
+++ b/test/less/mixin-args-guards.less
@@ -29,6 +29,8 @@
 	.mixin1(11);
 	.mixin1(-11);
 }
+.eq (@a, @b) when (@a < @b) and (@b = @a) {
+}
 .max (@a, @b) when (@a > @b) { 
 	width: @a 
 }


### PR DESCRIPTION
The following valid less code is not working as expected:

```less
.eq (@a, @b) when (@a < @b) and (@b = @a) {
}
```

This is the error output:

    Syntax Error, token: `css_filter`, `and (@b = @a)`