### PR TITLE
Syntax Error, token: `t_bopen`, `{`

### DIFF
--- a/lesscpy/lessc/lexer.py
+++ b/lesscpy/lessc/lexer.py
@@ -117,6 +117,7 @@ class LessLexer:
 
     def t_t_bopen(self, t):
         r'\{'
+        t.lexer.in_property_decl = False
         return t
 
     def t_t_bclose(self, t):

--- a/test/css/nesting.css
+++ b/test/css/nesting.css
@@ -21,6 +21,9 @@ h2 p:hover,
 h3 p:hover {
 	color: red;
 }
+a.btn-small span {
+	font-size: 10px;
+}
 a {
 	color: red;
 }

--- a/test/css/nesting.min.css
+++ b/test/css/nesting.min.css
@@ -4,6 +4,7 @@
 .div .nest.deep .deeper{color:angry;}
 .div .nest.deep .deeper .deepest{color:purple;}
 h1 a:hover,h2 a:hover,h3 a:hover,h1 p:hover,h2 p:hover,h3 p:hover{color:red;}
+a.btn-small span{font-size:10px;}
 a{color:red;}
 a:hover{color:blue;}
 div a{color:green;}

--- a/test/less/nesting.less
+++ b/test/less/nesting.less
@@ -28,6 +28,15 @@ h1, h2, h3 {
   	}
 }
 a {
+    &.btn {
+        &-small {
+            span {
+                font-size: 10px;
+            }
+        }
+    }
+}
+a {
   	color: red;
   	&:hover { color: blue; }
   	div & { color: green; }


### PR DESCRIPTION
I'm trying to compile the following rules:

``` less
a {
    &.btn {
        &-small {
            span {
                font-size: 10px;
            }
        }
    }
}
```

But I'm receiving this error

```
Syntax Error, token: `t_bopen`, `{`
```
