### PR TITLE
Remove duplicated feature : "Keyframe blocks"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,6 @@ Supported features
 - Color functions (lighten, darken, saturate, desaturate, spin, hue, mix,
                    saturation, lightness)
 - Other functions (round, increment, decrement, format '%(', ...)
-- Keyframe blocks
 
 
 Differences from less.js


### PR DESCRIPTION
It's already written line 54 that lesscpy supports Keyframe blocks