### PR TITLE
Access `file.name` as a property

### DIFF
--- a/lesscpy/lessc/parser.py
+++ b/lesscpy/lessc/parser.py
@@ -143,7 +143,7 @@ class LessParser(object):
                 if filename is not None:
                     raise AssertionError(
                         'names of file and filename are in conflict')
-                filename = file.name()
+                filename = file.name
             else:
                 filename = '(stream)'
 
@@ -1047,4 +1047,3 @@ class LessParser(object):
             t(str): Error type
         """
         self.register.register("%s: line: %d: %s\n" % (t, line, e))
-

--- a/test/test_pycompile.py
+++ b/test/test_pycompile.py
@@ -14,12 +14,24 @@ class TestCompileFunction(unittest.TestCase):
     Unit tests for compile
     """
 
-    def test_compile(self):
+    def test_compile_from_stream(self):
         """
         It can compile input from a file-like object
         """
 
         output = compile(StringIO("a { border-width: 2px * 3; }"), minify=True)
+        self.assertEqual(output, "a{border-width:6px;}");
+
+    def test_compile_from_file(self):
+        """
+        It can compile input from a file object
+        """
+
+        import tempfile
+        in_file = tempfile.NamedTemporaryFile(mode='w+')
+        in_file.write("a { border-width: 2px * 3; }")
+        in_file.seek(0)
+        output = compile(in_file, minify=True)
         self.assertEqual(output, "a{border-width:6px;}");
 
     def test_raises_exception(self):
@@ -30,4 +42,3 @@ class TestCompileFunction(unittest.TestCase):
 
         fail_func = lambda: compile(StringIO("a }"), minify=True)
         self.assertRaises(CompilationError, fail_func)
-


### PR DESCRIPTION
`file.name` is a property, not a function. The parser
was calling it as a function, causing it to fail when trying
to open actual file objects.