### PR TITLE
Make it work no matter what encoding the system use

### DIFF
--- a/lesscpy/lessc/lexer.py
+++ b/lesscpy/lessc/lexer.py
@@ -471,7 +471,7 @@ class LessLexer:
         like object.
         """
         if isinstance(file, string_types):
-            with open(file) as f:
+            with open(file, encoding="utf8", errors='ignore') as f:
                 self.lexer.input(f.read())
         else:
             self.lexer.input(file.read())


### PR DESCRIPTION
Problem about encoding occured in [jupyter-theme](https://github.com/dunovank/jupyter-themes)

Pull request info to fix this in `jupyter-theme` : https://github.com/dunovank/jupyter-themes/commit/7b9f32cfc1c4cdde94e3aed1c994fe7ef549213b

And this pull request is accepted in `jupyter-theme` but it depends on `lesscpy` so I send pull request here.

Please check it out and reflect my pull request

Thanks
