### PR TITLE
Make use of six.string_types consistent

### DIFF
--- a/lesscpy/lessc/color.py
+++ b/lesscpy/lessc/color.py
@@ -12,7 +12,7 @@ import operator
 
 import colorsys
 import re
-import six
+from six import string_types
 from . import utility
 from lesscpy.lib import colors
 
@@ -304,7 +304,7 @@ class Color():
             str
         """
         if color and degree:
-            if isinstance(degree, six.string_types):
+            if isinstance(degree, string_types):
                 degree = float(degree.strip('%'))
             h, l, s = self._hextohls(color)
             h = ((h * 360.0) + degree) % 360.0
@@ -348,7 +348,7 @@ class Color():
             str
         """
         if color1 and color2:
-            if isinstance(weight, six.string_types):
+            if isinstance(weight, string_types):
                 weight = float(weight.strip('%'))
             weight = ((weight / 100.0) * 2) - 1
             rgb1 = self._hextorgb(color1)
@@ -417,7 +417,7 @@ class Color():
         return colorsys.rgb_to_hls(*[c / 255.0 for c in rgb])
 
     def _ophsl(self, color, diff, idx, operation):
-        if isinstance(diff, six.string_types):
+        if isinstance(diff, string_types):
             diff = float(diff.strip('%'))
         hls = list(self._hextohls(color))
         hls[idx] = self._clamp(operation(hls[idx], diff / 100.0))

--- a/lesscpy/lessc/parser.py
+++ b/lesscpy/lessc/parser.py
@@ -18,7 +18,7 @@ import os
 import tempfile
 import sys
 import ply.yacc
-import six
+from six import string_types
 
 from . import lexer
 from . import utility
@@ -236,7 +236,7 @@ class LessParser(object):
         if self.importlvl > 8:
             raise ImportError(
                 'Recrusive import level too deep > 8 (circular import ?)')
-        if isinstance(p[3], six.string_types):
+        if isinstance(p[3], string_types):
             ipath = utility.destring(p[3])
         elif isinstance(p[3], list):
             p[3] = Import(p[3], p.lineno(4)).parse(self.scope)

--- a/lesscpy/lessc/scope.py
+++ b/lesscpy/lessc/scope.py
@@ -7,7 +7,7 @@
     See LICENSE for details.
 .. moduleauthor:: Johann T. Mariusson <jtm@robot.is>
 """
-import six
+from six import string_types
 
 from . import utility
 
@@ -195,7 +195,7 @@ class Scope(list):
             var = self.variables('@' + name[2:-1])
             if var is False:
                 raise SyntaxError('Unknown escaped variable %s' % name)
-            if isinstance(var.value[0], six.string_types):
+            if isinstance(var.value[0], string_types):
                 var.value[0] = utility.destring(var.value[0])
         else:
             var = self.variables(name)

--- a/lesscpy/plib/call.py
+++ b/lesscpy/plib/call.py
@@ -13,7 +13,7 @@ try:
     from urllib.parse import quote as urlquote
 except ImportError:
     from urllib import quote as urlquote
-import six
+from six import string_types
 from .node import Node
 import lesscpy.lessc.utility as utility
 import lesscpy.lessc.color as Color
@@ -46,7 +46,7 @@ class Call(Node):
             name = 'escape'
         color = Color.Color()
         args = [t for t in parsed
-                if not isinstance(t, six.string_types) or t not in '(),']
+                if not isinstance(t, string_types) or t not in '(),']
         if hasattr(self, name):
             try:
                 return getattr(self, name)(*args)

--- a/lesscpy/plib/negated_expression.py
+++ b/lesscpy/plib/negated_expression.py
@@ -7,7 +7,7 @@
     See LICENSE for details.
 """
 
-import six
+from six import string_types
 
 from .node import Node
 
@@ -18,6 +18,6 @@ class NegatedExpression(Node):
 
     def parse(self, scope):
         val, = self.process(self.tokens, scope)
-        if isinstance(val, six.string_types):
+        if isinstance(val, string_types):
             return '-' + val
         return -val


### PR DESCRIPTION
Small cleanup. Some places have `import six` and then use `six.string_types` while some have `from six import string_types`.

As `string_types` is the only thing used, make all files use `from six import string_types`

The tests are already consistent by using `from six import StringIO`