### PR TITLE
Basic support for CSS4 variables

### DIFF
--- a/lesscpy/less.ast
+++ b/lesscpy/less.ast
@@ -75,6 +75,7 @@
         
  property    			: css_property
                         | css_vendor_property
+                        | css_user_property
                         | css_ident
         
  style_list        		: style_group
@@ -89,6 +90,7 @@
                         | css_string
                         | istring
                         | css_vendor_property
+                        | css_user_property
                         | css_property
                         | css_ident
         				| '~' istring
@@ -136,6 +138,7 @@ factor           		: color
                         | css_ident
                         | css_id
                         | css_uri
+                        | css_user_property
                         | '='
         
  istring         		: less_string

--- a/lesscpy/lessc/lexer.py
+++ b/lesscpy/lessc/lexer.py
@@ -32,18 +32,18 @@ class LessLexer:
     literals = '<>=%!/*-+&'
     tokens = [
         'css_ident', 'css_dom', 'css_class', 'css_id', 'css_property',
-        'css_vendor_property', 'css_comment', 'css_string', 'css_color',
-        'css_filter', 'css_number', 'css_important', 'css_vendor_hack',
-        'css_uri', 'css_ms_filter', 'css_keyframe_selector', 'css_media_type',
-        'css_media_feature', 't_and', 't_not', 't_only', 'less_variable',
-        'less_comment', 'less_open_format', 'less_when', 'less_and',
-        'less_not', 't_ws', 't_popen', 't_pclose', 't_semicolon', 't_tilde',
-        't_colon', 't_comma', 't_eopen', 't_eclose', 't_isopen', 't_isclose',
-        't_bopen', 't_bclose'
+        'css_vendor_property', 'css_user_property', 'css_comment',
+        'css_string', 'css_color', 'css_filter', 'css_number', 'css_important',
+        'css_vendor_hack', 'css_uri', 'css_ms_filter', 'css_keyframe_selector',
+        'css_media_type', 'css_media_feature', 't_and', 't_not', 't_only',
+        'less_variable', 'less_comment', 'less_open_format', 'less_when',
+        'less_and', 'less_not', 't_ws', 't_popen', 't_pclose', 't_semicolon',
+        't_tilde', 't_colon', 't_comma', 't_eopen', 't_eclose', 't_isopen',
+        't_isclose', 't_bopen', 't_bclose'
     ]
     tokens += list(set(reserved.tokens.values()))
     # Tokens with significant following whitespace
-    significant_ws = {'css_class', 'css_id', 'css_dom', 'css_property', 'css_vendor_property', 'css_ident',
+    significant_ws = {'css_class', 'css_id', 'css_dom', 'css_property', 'css_vendor_property', 'css_user_property', 'css_ident',
                       'css_number', 'css_color', 'css_media_type', 'css_filter', 'less_variable', 't_and', 't_not',
                       't_only', '&'}
     significant_ws.update(reserved.tokens.values())
@@ -87,7 +87,7 @@ class LessLexer:
         return t
 
     def t_css_ident(self, t):
-        (r'([\-\.\#]?'
+        (r'((\-|\.|\#|\-\-)?'
          '([_a-z]'
          '|[\200-\377]'
          '|\\\[0-9a-f]{1,6}'
@@ -132,6 +132,9 @@ class LessLexer:
             # DOM elements can't be part of property declarations, avoids ambiguity between 'rect' DOM
             # element and rect() CSS function.
             t.type = 'css_dom'
+        elif v.startswith("--"):
+            t.type = 'css_user_property'
+            t.lexer.in_property_decl = True
         elif c == '-':
             t.type = 'css_vendor_property'
             t.lexer.in_property_decl = True

--- a/lesscpy/lessc/parser.py
+++ b/lesscpy/lessc/parser.py
@@ -494,6 +494,7 @@ class LessParser(object):
     def p_prop_open(self, p):
         """ prop_open               : property t_colon
                                     | vendor_property t_colon
+                                    | user_property t_colon
                                     | word t_colon
         """
         p[0] = (p[1][0], '')
@@ -771,6 +772,7 @@ class LessParser(object):
                             | word
                             | id
                             | css_uri
+                            | css_user_property
                             | '='
                             | fcall
         """
@@ -964,6 +966,12 @@ class LessParser(object):
     def p_vendor_property(self, p):
         """ vendor_property           : css_vendor_property
                                       | css_vendor_property t_ws
+        """
+        p[0] = tuple(list(p)[1:])
+
+    def p_user_property(self, p):
+        """ user_property             : css_user_property
+                                      | css_user_property t_ws
         """
         p[0] = tuple(list(p)[1:])
 

--- a/test/css/css-variables.css
+++ b/test/css/css-variables.css
@@ -1,0 +1,17 @@
+:root {
+	--bg: #e0e0e0;
+}
+p {
+	--bg: white;
+}
+* {
+	background: var(--bg);
+	color: var(--fg,var(--text-fg,black));
+}
+div {
+	--bg: red;
+}
+div span {
+	--bg: purple;
+	background: var(--bg);
+}

--- a/test/css/css-variables.min.css
+++ b/test/css/css-variables.min.css
@@ -1,0 +1,5 @@
+:root{--bg:#e0e0e0;}
+p{--bg:white;}
+*{background:var(--bg);color:var(--fg,var(--text-fg,black));}
+div{--bg:red;}
+div span{--bg:purple;background:var(--bg);}

--- a/test/less/css-variables.less
+++ b/test/less/css-variables.less
@@ -1,0 +1,21 @@
+:root {
+  --bg: #e0e0e0;
+}
+
+p {
+  --bg: white;
+}
+
+* {
+  background: var(--bg);
+  color: var(--fg, var(--text-fg, black));
+}
+
+div {
+  --bg: red;
+
+  span {
+    --bg: purple;
+    background: var(--bg);
+  }
+}


### PR DESCRIPTION
This PR adds simple support for [CSS4 variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) by defining one new token and one new AST node, both named `user_property`, which correspond to properties of the form `--name`.

* The regex for `t_ident` is extended to allow `--` as a prefix.
* The parsing rules for `prop_open` is extended to allow `user_property t_colon`.
* The parsing rule for `argument` (of function calls) also allows `user_property` so that `var(--name)` can be parsed.
* No change was needed to support `var()` or the `:root` filter.

This PR should hopefully fix #113, assuming everything is in order. ^^